### PR TITLE
feat: Add GitHub Action for RDoc generation and deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3' # Or your project's Ruby version
+          bundler-cache: true # Optional: if you use Bundler
+      - name: Install rdoc
+        run: gem install rdoc
+      - name: Generate documentation
+        run: rdoc --main README.md -o ./docs/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![.github/workflows/main.yml](https://github.com/elct9620/line-message-builder/actions/workflows/main.yml/badge.svg)](https://github.com/elct9620/line-message-builder/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/elct9620/line-message-builder/graph/badge.svg?token=9TJTSRIL0X)](https://codecov.io/gh/elct9620/line-message-builder)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/elct9620/line-message-builder)
+[![Documentation](https://img.shields.io/badge/docs-gh--pages-brightgreen)](https://elct9620.github.io/line-message-builder/)
 
 Build LINE messages using DSL (Domain Specific Language) in Ruby.
 


### PR DESCRIPTION
I've set up a new GitHub Actions workflow for you that will:
- Generate HTML documentation from your README.md using rdoc.
- Deploy the generated documentation to GitHub Pages.

This workflow will run whenever you push to the main branch. It installs rdoc, generates the documentation into a `docs` directory, and then uses `actions/upload-pages-artifact` and `actions/deploy-pages` to publish the site.

I've also added a badge to your README.md that links to the new documentation page.